### PR TITLE
Linter fixes + README cleanup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -16,3 +16,4 @@ src
 node_modules/
 .github/
 *.log
+*.md

--- a/.eslintrc
+++ b/.eslintrc
@@ -5,11 +5,40 @@
   },
   "extends": ["airbnb-base", "prettier"],
   "parser": "babel-eslint",
+  "overrides": [
+    {
+      "files": ["**/*.ts", "**/*.tsx"],
+      "env": { "es6": true, "node": true },
+      "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended"
+      ],
+      "globals": { "Atomics": "readonly", "SharedArrayBuffer": "readonly" },
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        "ecmaFeatures": { "jsx": true },
+        "ecmaVersion": 2018,
+        "sourceType": "module",
+        "project": "./tsconfig.json"
+      },
+      "plugins": ["@typescript-eslint"],
+      "rules": {
+        "indent": ["error", 2, { "SwitchCase": 1 }],
+        "linebreak-style": ["error", "unix"],
+        "@typescript-eslint/no-explicit-any": 0,
+        "@typescript-eslint/no-useless-constructor": 0
+      }
+    }
+  ],
   "parserOptions": {
     "ecmaVersion": 12,
     "sourceType": "module"
   },
   "rules": {
-    "indent": ["error", 2]
+    "indent": ["error", 2],
+    "no-useless-constructor": 0,
+    "no-param-reassign": 0,
+    "max-classes-per-file": ["error", 3]
   }
 }

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ TorchJS is a JS binding for PyTorch. Its primary objective is to allow running [
 
 ## Changes after fork
 
-- Support ```List``` (Javascript ```Array```), ```Dict``` (Javascript ```Object```), ```String```, ```float``` (Javascript ```number```) as inputs and outputs.
+- Support `List` (Javascript `Array`), `Dict` (Javascript `Object`), `String`, `float` (Javascript `number`) as inputs and outputs.
 
 - Add CUDA support.
 
 - Add ops from torchvision.
 
-- Add async support for ```forward``` function.
+- Add async support for `forward` function.
 
 ## Install
 
@@ -24,7 +24,7 @@ yarn add torch-js@npm:@arition/torch-js
 
 ## Example
 
-In `test/torch_module.py`, you will find the defination of our test module and the code to generate the trace file.
+In `tests/resources/torch_module.py`, you will find the defination of our test module and the code to generate the trace file.
 
 ```python
 class TestModule(torch.nn.Module):
@@ -35,110 +35,22 @@ class TestModule(torch.nn.Module):
         return input1 + input2
 ```
 
-Once you have the trace file, you can load it into Node.js like this
+Once you have the trace file, it may be loaded into NodeJS like this
+
+```javascript
+
+```
 
 ```javascript
 const torch = require("torch-js");
-
-(async () => {
-  var test_model_path = "test/test_model.pt";
-
-  var script_module = new torch.ScriptModule(test_model_path);
-  console.log(script_module.toString());
-
-  var a = torch.rand(1, 5);
-  console.log(a.toObject());
-  var b = torch.rand([1, 5]);
-  console.log(b.toObject());
-
-  var c = await script_module.forward(a, b);
-  console.log(c.toObject());
-
-  var d = torch.tensor([[0.1, 0.2, 0.3, 0.4, 0.5]]);
-  console.log(d.toObject());
-
-  var e = await script_module.forward(c, d);
-  console.log(e.toObject());
-})();
+const modelPath = `test_model.pt`;
+const model = new torch.ScriptModule(testModelPath);
+const inputA = torch.rand([1, 5]);
+const inputB = torch.rand([1, 5]);
+const res = await model.forward(inputA, inputB);
 ```
 
-The program above will print something like this on console. Your result will be different from this since `a` and `b` are random variables.
-
-```javascript
-ScriptModule("/Users/kittipat/torchjs/tests/test_model.pt")
-{ data:
-   Float32Array [
-     0.5436246991157532,
-     0.30234378576278687,
-     0.4031236171722412,
-     0.8123507499694824,
-     0.3121740221977234 ],
-  shape: [ 1, 5 ] }
-{ data:
-   Float32Array [
-     0.20072013139724731,
-     0.09114563465118408,
-     0.588677167892456,
-     0.14665216207504272,
-     0.8567551374435425 ],
-  shape: [ 1, 5 ] }
-{ data:
-   Float32Array [
-     0.7443448305130005,
-     0.39348942041397095,
-     0.9918007850646973,
-     0.9590029120445251,
-     1.168929100036621 ],
-  shape: [ 1, 5 ] }
-{ data:
-   Float32Array [
-     0.10000000149011612,
-     0.20000000298023224,
-     0.30000001192092896,
-     0.4000000059604645,
-     0.5 ],
-  shape: [ 1, 5 ] }
-{ data:
-   Float32Array [
-     0.8443448543548584,
-     0.593489408493042,
-     1.2918007373809814,
-     1.359002947807312,
-     1.668929100036621 ],
-  shape: [ 1, 5 ] }
-```
-
-### Tensor creation
-
-There are several ways to create tensors
-
-```javascript
-// With TypedArray and shape array
-var a = torch.tensor(
-  new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5]), {
-    shape: [1, 5],
-  });
-
-// With array, will create tensor with float32 data type
-var b = torch.tensor([
-  [0.1, 0.2, 0.3],
-  [0.4, 0.5, 0.6],
-]);
-
-// With array and option object
-var c = torch.tensor([
-  [0.1, 0.2, 0.3],
-  [0.4, 0.5, 0.6],
-], {
-  dtype: torch.float64
-});
-
-// With torch.Tensor.fromObject()
-var d = torch.Tensor.fromObject({
-  data: new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
-  shape: [2, 3],
-});
-```
+More examples regarding tensor creation, ScriptModule operations, and loading models can be found in our [examples](./examples) folder.
 
 ## Installation
 

--- a/examples/ScriptModule.md
+++ b/examples/ScriptModule.md
@@ -1,0 +1,14 @@
+# Sample ScriptModule Usage
+
+## forward
+
+The script_module may be used to load up any model in TorchScript, and perform operations on it
+
+```js
+const torch = require("torch-js");
+const modelPath = `test_model.pt`;
+const model = new torch.ScriptModule(testModelPath);
+const inputA = torch.rand([1, 5]);
+const inputB = torch.rand([1, 5]);
+const res = await model.forward(inputA, inputB);
+```

--- a/examples/Tensor.md
+++ b/examples/Tensor.md
@@ -1,49 +1,60 @@
 # Sample Tensor Creation
 
 ## Rand
+
 The rand function may be used to generate a tensor of a given shape and configuration, populated with random values
 
 ### Calling rand with variable number of arguments
+
 ```js
 const a = torch.rand(1, 5);
 ```
 
 ### Calling rand with shape array
+
 ```js
 const a = torch.rand([1, 5]);
 ```
 
 ### Calling rand using option parsing
+
 ```js
 const a = torch.rand([1, 5], {
-    dtype: torch.float64
+  dtype: torch.float64,
 });
 ```
 
 ### Calling rand using option parsing
+
 ```js
 const a = torch.rand([1, 5], {
-    dtype: torch.float64
+  dtype: torch.float64,
 });
 ```
+
 ## Tensor
+
 The tensor function may be used to create a tensor given an array of values that the tensor would consist of.
 
 ### Calling tensor given a nested array of tensor values
+
 ```js
 const a = torch.tensor([
-    [0.1, 0.2, 0.3],
-    [0.4, 0.5, 0.6],
+  [0.1, 0.2, 0.3],
+  [0.4, 0.5, 0.6],
 ]);
 ```
 
 ### Calling tensor given a nested array of tensor values and a specified option type
+
 ```js
-const a = torch.tensor([
+const a = torch.tensor(
+  [
     [0.1, 0.2, 0.3],
     [0.4, 0.5, 0.6],
-], {
-    dtype: torch.float64
-});
+  ],
+  {
+    dtype: torch.float64,
+  }
+);
 ```
-

--- a/lib/bindings.d.ts
+++ b/lib/bindings.d.ts
@@ -1,10 +1,10 @@
 type bindingFunction = (mod: string) => any;
 interface bindingInterface extends bindingFunction {
   getRoot: (file: string) => string;
-  getFileName: (calling_file?: string) => string;
+  getFileName: (callingFile?: string) => string;
 }
-declare var bindings: bindingInterface;
+declare let bindings: bindingInterface;
 
-declare module 'bindings' {
+declare module "bindings" {
   export = bindings;
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,13 +1,14 @@
-'use strict';
-import assert = require('assert');
-import torch = require('./torch');
-export * from './torch';
+import assert = require("assert");
+import torch = require("./torch");
 
-type Matrix = number[]|NestedArray;
-interface NestedArray extends Array<Matrix> {}
+export * from "./torch";
+
+// eslint-disable-next-line no-use-before-define
+type Matrix = number[] | NestedArray;
+type NestedArray = Array<Matrix>;
 
 function flattenArray(arr: Matrix) {
-  let shape = [arr.length];
+  const shape = [arr.length];
   while (arr.length > 0 && Array.isArray(arr[0])) {
     shape.push((arr[0] as Matrix).length);
     // Forcing Array<any> is required to make TS happy; otherwise, TS2349
@@ -18,8 +19,9 @@ function flattenArray(arr: Matrix) {
     assert.strictEqual(arr.length, numel);
   }
   return {
-    data: (arr as number[]), shape: shape,
-  }
+    data: arr as number[],
+    shape,
+  };
 }
 
 function typedArrayType(dtype: number) {
@@ -31,28 +33,29 @@ function typedArrayType(dtype: number) {
     case torch.int32:
       return Int32Array;
     default:
-      throw new TypeError('Unsupported dtype');
+      throw new TypeError("Unsupported dtype");
   }
 }
 
-type TensorDataCompatible = Float32Array|Float64Array|Int32Array|Matrix;
+type TensorDataCompatible = Float32Array | Float64Array | Int32Array | Matrix;
 
 export function tensor(
-    data: TensorDataCompatible,
-    {dtype = torch.float32, shape}: {dtype?: number, shape?: number[]} = {}) {
+  data: TensorDataCompatible,
+  { dtype = torch.float32, shape }: { dtype?: number; shape?: number[] } = {}
+): torch.Tensor {
   if (Array.isArray(data)) {
-    const array_and_shape = flattenArray(data);
-    const typed_array = new (typedArrayType(dtype))(array_and_shape.data);
+    const arrayAndShape = flattenArray(data);
+    const typedArray = new (typedArrayType(dtype))(arrayAndShape.data);
     return torch.Tensor.fromObject({
-      data: typed_array,
-      shape: array_and_shape.shape,
+      data: typedArray,
+      shape: arrayAndShape.shape,
     });
   }
   if (shape === undefined) {
     shape = [data.length];
   }
   return torch.Tensor.fromObject({
-    data: data,
-    shape: shape,
+    data,
+    shape,
   });
 }

--- a/lib/torch.d.ts
+++ b/lib/torch.d.ts
@@ -4,43 +4,65 @@ export const float64: number;
 export const int32: number;
 
 export interface ObjectTensor {
-  data: Float32Array|Float64Array|Int32Array;
+  data: Float32Array | Float64Array | Int32Array;
   shape: number[];
 }
 
 export class Tensor {
-  static fromObject({data, shape}: ObjectTensor): Tensor;
+  static fromObject({ data, shape }: ObjectTensor): Tensor;
+
   toObject(): ObjectTensor;
+
   toString(): string;
+
   cpu(): Tensor;
+
   cuda(): Tensor;
+
   clone(): Tensor;
+
   /**
    * Free the underlying tensor resources.
-   * 
+   *
    * DO NOT use the object again after calling the method.
    */
   free(): void;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface TorchTypesArray extends Array<TorchTypes> {}
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface TorchTypesRecord extends Record<string | number | symbol, TorchTypes> {}
+// raghavmecheri - FIXTHIS: Get rid of circular dependancies if possible
 
-type TorchTypes = TorchTypesArray | TorchTypesRecord | string | number | boolean | Tensor
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, no-use-before-define
+interface TorchTypesArray extends Array<TorchTypes> {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, no-use-before-define
+interface TorchTypesRecord
+  extends Record<string | number | symbol, TorchTypes> {}
+
+type TorchTypes =
+  | TorchTypesArray
+  | TorchTypesRecord
+  | string
+  | number
+  | boolean
+  | Tensor;
 
 export class ScriptModule {
   constructor(path: string);
+
   forward(input: TorchTypes): Promise<TorchTypes>;
+
   forward(...inputs: TorchTypes[]): Promise<TorchTypes>;
+
   toString(): string;
+
   cpu(): ScriptModule;
+
   cuda(): ScriptModule;
+
   static isCudaAvailable(): boolean;
 }
 
-export function rand(shape: number[], options?: {dtype?: number}): Tensor;
+export function rand(shape: number[], options?: { dtype?: number }): Tensor;
 // The function actually support options at the end but TS can't express that
-export function rand(...shape: number[] /**, options?: {dtype?: number} */):
-    Tensor;
+export function rand(
+  ...shape: number[] /** , options?: {dtype?: number} */
+): Tensor;

--- a/lib/torch.d.ts
+++ b/lib/torch.d.ts
@@ -33,9 +33,8 @@ export class Tensor {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, no-use-before-define
 interface TorchTypesArray extends Array<TorchTypes> {}
-// eslint-disable-next-line @typescript-eslint/no-empty-interface, no-use-before-define
-interface TorchTypesRecord
-  extends Record<string | number | symbol, TorchTypes> {}
+interface TorchTypesRecord // eslint-disable-line @typescript-eslint/no-empty-interface
+  extends Record<string | number | symbol, TorchTypes> {} // eslint-disable-line no-use-before-define
 
 type TorchTypes =
   | TorchTypesArray

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "@babel/preset-env": "^7.11.5",
     "@jest/globals": "^26.5.2",
     "@types/node": "^14.6.0",
+    "@typescript-eslint/eslint-plugin": "^4.4.0",
+    "@typescript-eslint/parser": "^4.4.0",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.10.0",
     "eslint-config-airbnb-base": "^14.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1099,6 +1099,27 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@nodelib/fs.scandir@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
+  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.3"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
+  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
+  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.3"
+    fastq "^1.6.0"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
@@ -1172,15 +1193,20 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/json-schema@^7.0.3":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
+  integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
 "@types/node@*", "@types/node@^14.6.0":
-  version "14.11.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.5.tgz#fecad41c041cae7f2404ad4b2d0742fdb628b305"
-  integrity sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ==
+  version "14.11.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.8.tgz#fe2012f2355e4ce08bca44aeb3abbb21cf88d33f"
+  integrity sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -1193,9 +1219,9 @@
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/prettier@^2.0.0":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.1.tgz#be148756d5480a84cde100324c03a86ae5739fb5"
-  integrity sha512-2zs+O+UkDsJ1Vcp667pd3f8xearMdopz/z54i99wtRDI5KLmngk7vlrYZD0ZjKHaROR03EznlBbVY9PfAEyJIQ==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.2.tgz#4929992f87a0129f4960a110faeb526210562e7b"
+  integrity sha512-IiPhNnenzkqdSdQH3ifk9LoX7oQe61ZlDdDO4+MUv6FyWdPGDPr26gCPVs3oguZEMq//nFZZpwUZcVuNJsG+DQ==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
@@ -1208,11 +1234,81 @@
   integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
 
 "@types/yargs@^15.0.0":
-  version "15.0.7"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.7.tgz#dad50a7a234a35ef9460737a56024287a3de1d2b"
-  integrity sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==
+  version "15.0.8"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.8.tgz#7644904cad7427eb704331ea9bf1ee5499b82e23"
+  integrity sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@typescript-eslint/eslint-plugin@^4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.4.0.tgz#0321684dd2b902c89128405cf0385e9fe8561934"
+  integrity sha512-RVt5wU9H/2H+N/ZrCasTXdGbUTkbf7Hfi9eLiA8vPQkzUJ/bLDCC3CsoZioPrNcnoyN8r0gT153dC++A4hKBQQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "4.4.0"
+    "@typescript-eslint/scope-manager" "4.4.0"
+    debug "^4.1.1"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.0.0"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/experimental-utils@4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.4.0.tgz#62a05d3f543b8fc5dec4982830618ea4d030e1a9"
+  integrity sha512-01+OtK/oWeSJTjQcyzDztfLF1YjvKpLFo+JZmurK/qjSRcyObpIecJ4rckDoRCSh5Etw+jKfdSzVEHevh9gJ1w==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/scope-manager" "4.4.0"
+    "@typescript-eslint/types" "4.4.0"
+    "@typescript-eslint/typescript-estree" "4.4.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/parser@^4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.4.0.tgz#65974db9a75f23b036f17b37e959b5f99b659ec0"
+  integrity sha512-yc14iEItCxoGb7W4Nx30FlTyGpU9r+j+n1LUK/exlq2eJeFxczrz/xFRZUk2f6yzWfK+pr1DOTyQnmDkcC4TnA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "4.4.0"
+    "@typescript-eslint/types" "4.4.0"
+    "@typescript-eslint/typescript-estree" "4.4.0"
+    debug "^4.1.1"
+
+"@typescript-eslint/scope-manager@4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.4.0.tgz#2f3dd27692a12cc9a046a90ba6a9d8cb7731190a"
+  integrity sha512-r2FIeeU1lmW4K3CxgOAt8djI5c6Q/5ULAgdVo9AF3hPMpu0B14WznBAtxrmB/qFVbVIB6fSx2a+EVXuhSVMEyA==
+  dependencies:
+    "@typescript-eslint/types" "4.4.0"
+    "@typescript-eslint/visitor-keys" "4.4.0"
+
+"@typescript-eslint/types@4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.4.0.tgz#63440ef87a54da7399a13bdd4b82060776e9e621"
+  integrity sha512-nU0VUpzanFw3jjX+50OTQy6MehVvf8pkqFcURPAE06xFNFenMj1GPEI6IESvp7UOHAnq+n/brMirZdR+7rCrlA==
+
+"@typescript-eslint/typescript-estree@4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.4.0.tgz#16a2df7c16710ddd5406b32b86b9c1124b1ca526"
+  integrity sha512-Fh85feshKXwki4nZ1uhCJHmqKJqCMba+8ZicQIhNi5d5jSQFteWiGeF96DTjO8br7fn+prTP+t3Cz/a/3yOKqw==
+  dependencies:
+    "@typescript-eslint/types" "4.4.0"
+    "@typescript-eslint/visitor-keys" "4.4.0"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/visitor-keys@4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.4.0.tgz#0a9118344082f14c0f051342a74b42dfdb012640"
+  integrity sha512-oBWeroUZCVsHLiWRdcTXJB7s1nB3taFY8WGvS23tiAlT6jXVvsdAV4rs581bgdEjOhn43q6ro7NkOiLKu6kFqA==
+  dependencies:
+    "@typescript-eslint/types" "4.4.0"
+    eslint-visitor-keys "^2.0.0"
 
 abab@^2.0.3:
   version "2.0.5"
@@ -1401,6 +1497,11 @@ array-index@^1.0.0:
   dependencies:
     debug "^2.2.0"
     es6-symbol "^3.0.2"
+
+array-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -1756,9 +1857,9 @@ camelcase@^6.0.0:
   integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
 
 caniuse-lite@^1.0.30001135:
-  version "1.0.30001144"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001144.tgz#bca0fffde12f97e1127a351fec3bfc1971aa3b3d"
-  integrity sha512-4GQTEWNMnVZVOFG3BK0xvGeaDAtiPAbG2N8yuMXuXzx/c2Vd4XoMPO8+E918zeXn5IF0FRVtGShBfkfQea2wHQ==
+  version "1.0.30001146"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001146.tgz#c61fcb1474520c1462913689201fb292ba6f447c"
+  integrity sha512-VAy5RHDfTJhpxnDdp2n40GPPLp3KqNrXz1QqFv4J64HvArKs8nuNMOWkB3ICOaBTU/Aj4rYAo/ytdQDDFF/Pug==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -2235,6 +2336,13 @@ diff-sequences@^26.5.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.5.0.tgz#ef766cf09d43ed40406611f11c6d8d9dd8b2fefd"
   integrity sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==
 
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
+
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -2478,7 +2586,7 @@ eslint-plugin-import@^2.22.1:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
-eslint-scope@^5.1.1:
+eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -2486,7 +2594,7 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-utils@^2.1.0:
+eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
@@ -2498,10 +2606,15 @@ eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
+eslint-visitor-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
+  integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
+
 eslint@^7.10.0:
-  version "7.10.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.10.0.tgz#494edb3e4750fb791133ca379e786a8f648c72b9"
-  integrity sha512-BDVffmqWl7JJXqCjAK6lWtcQThZB/aP1HXSH1JKwGwv0LQEdvpR7qzNrUT487RM39B5goWuboFad5ovMBmD8yA==
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.11.0.tgz#aaf2d23a0b5f1d652a08edacea0c19f7fadc0b3b"
+  integrity sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@eslint/eslintrc" "^0.1.3"
@@ -2513,7 +2626,7 @@ eslint@^7.10.0:
     enquirer "^2.3.5"
     eslint-scope "^5.1.1"
     eslint-utils "^2.1.0"
-    eslint-visitor-keys "^1.3.0"
+    eslint-visitor-keys "^2.0.0"
     espree "^7.3.0"
     esquery "^1.2.0"
     esutils "^2.0.2"
@@ -2715,6 +2828,18 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-glob@^3.1.1:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
+  integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -2724,6 +2849,13 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fastq@^1.6.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.8.0.tgz#550e1f9f59bbc65fe185cb6a9b4d95357107f481"
+  integrity sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==
+  dependencies:
+    reusify "^1.0.4"
 
 fb-watchman@^2.0.0:
   version "2.0.1"
@@ -3010,7 +3142,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.0.0:
+glob-parent@^5.0.0, glob-parent@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
@@ -3051,6 +3183,18 @@ globals@^12.1.0:
   integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
   dependencies:
     type-fest "^0.8.1"
+
+globby@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
+  integrity sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.4"
@@ -3210,6 +3354,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.1.4:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
+  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.2.1"
@@ -4229,7 +4378,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4, lodash@^4.17.14, lodash@^4.17.19:
+lodash@^4, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -4303,6 +4452,11 @@ merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
+merge2@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
@@ -4945,7 +5099,7 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.0.5:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -5258,7 +5412,7 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexpp@^3.1.0:
+regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
@@ -5396,6 +5550,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
@@ -5426,6 +5585,11 @@ rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
+
+run-parallel@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
 run-waterfall@^1.1.6:
   version "1.1.6"
@@ -6161,10 +6325,17 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.9.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.0.tgz#d624983f3e2c5e0b55307c3dd6c86acd737622c6"
-  integrity sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw==
+tslib@^1.8.1, tslib@^1.9.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -6422,9 +6593,9 @@ whatwg-mimetype@^2.3.0:
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
 whatwg-url@^8.0.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.3.0.tgz#d1e11e565334486cdb280d3101b9c3fd1c867582"
-  integrity sha512-BQRf/ej5Rp3+n7k0grQXZj9a1cHtsp4lqj01p59xBWFKdezR8sO37XnpafwNqiFac/v2Il12EIMjX/Y4VZtT8Q==
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.4.0.tgz#50fb9615b05469591d2b2bd6dfaed2942ed72837"
+  integrity sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==
   dependencies:
     lodash.sortby "^4.7.0"
     tr46 "^2.0.2"


### PR DESCRIPTION
1. TypeScript breaks eslint unless you add a bunch of explicit rules for Typescript compatibility. Added those.
2. Cleaned up README, which was super long
3. Cleaned up `examples` and added a few additional examples to the set as well