### PR TITLE
WIP: Prebuild fix

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -17,3 +17,5 @@ node_modules/
 .github/
 *.log
 *.md
+*.txt
+*.sh

--- a/.prettierignore
+++ b/.prettierignore
@@ -18,3 +18,4 @@ node_modules/
 *.log
 *.zip
 *.txt
+*.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project (torch-js)
 
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 find_package(CUDA)
 if(CUDA_FOUND)
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/build/libtorch")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project (torch-js)
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set(MACOS TRUE)
-endif()
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 find_package(CUDA)
 if(CUDA_FOUND)

--- a/README.md
+++ b/README.md
@@ -38,10 +38,6 @@ class TestModule(torch.nn.Module):
 Once you have the trace file, it may be loaded into NodeJS like this
 
 ```javascript
-
-```
-
-```javascript
 const torch = require("torch-js");
 const modelPath = `test_model.pt`;
 const model = new torch.ScriptModule(testModelPath);

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,5 @@
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+	export LD_LIBRARY_PATH="$(pwd)/node_modules/\@arition/torch-js/build/libtorch:$(pwd)/node_modules/\@arition/torch-js/build/vision"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+	export DYLD_LIBRARY_PATH="$(pwd)/node_modules/\@arition/torch-js/build/libtorch:$(pwd)/node_modules/\@arition/torch-js/build/vision"
+fi

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/arition/torch-js.git"
   },
   "scripts": {
-    "install": "prebuild-install -r napi || cmake-js compile",
+    "install": "prebuild-install -r napi || source ./config.sh && cmake-js compile",
     "build": "node build.js",
     "compile": "cmake-js compile",
     "rebuild": "cmake-js rebuild",


### PR DESCRIPTION
Attempt 2 to close #7 

It looks like the best way to fix this is to set the `LD_LIBRARY_PATH` on Linux, or the `DYLD_LIBRARY_PATH` on macOS. I've added a bash script that exports the required variable, but I'm not sure how to test this -- do you know how I can tell prebuild to try and link a local artefact, instead of building everything from source?